### PR TITLE
Update djangorestframework dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.*
 dataclasses==0.*
-djangorestframework>=3.14.0,<3.16.0
+djangorestframework>=3.15.1,<3.16.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.*
 dataclasses==0.*
-djangorestframework==3.14.0
+djangorestframework>=3.15.1,<3.16.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.*
 dataclasses==0.*
-djangorestframework>=3.15.1,<3.16.0
+djangorestframework>=3.14.0,<3.16.0


### PR DESCRIPTION
The current version constraint for the `djangorestframework` dependency in the `payme-pkg` package is too specific and may cause compatibility issues for projects requiring different versions of `djangorestframework`.

To address this, I've updated the `requirements.txt` file to use a broader version constraint:
djangorestframework>=3.14.0,<3.16.0

This change should allow the `payme-pkg` package to work with `djangorestframework` version 3.14.0 and higher, including newer versions like the one required by my project (`^3.15.1`), while maintaining compatibility for existing users.

Additionally, it might be beneficial to consider the following improvements:

1. **Make the `djangorestframework` dependency version configurable**: Introduce a configuration option or setting that allows users to specify the desired version of `djangorestframework` based on their project requirements.

2. **Use environment variables for dependency versions**: Implement support for setting the required `djangorestframework` version using environment variables. This would provide more flexibility for users with different project requirements and deployment environments.

3. **Improve dependency management**: Explore more robust dependency management solutions, such as using a tool like Poetry or pipenv, which can handle dependency resolution and versioning more effectively.

I've tested the updated package locally with the broader `djangorestframework` dependency constraint, and it seems to work correctly. However, thorough testing across different project configurations and `djangorestframework` versions would be recommended before merging these changes.

Please review the proposed changes and let me know if you have any concerns or suggestions for further improvements.