### PR TITLE
Refactor type annotations

### DIFF
--- a/payme/classes/cards.py
+++ b/payme/classes/cards.py
@@ -19,7 +19,7 @@ class Cards:
     services. It allows you to create new cards and retrieve verification
     codes for existing cards.
     """
-    def __init__(self, url: str, payme_id: str) -> "Cards":
+    def __init__(self, url: str, payme_id: str) -> None:
         """
         Initialize the Cards client.
 

--- a/payme/classes/client.py
+++ b/payme/classes/client.py
@@ -1,5 +1,4 @@
-
-from typing import Union
+import typing as t
 
 from payme.const import Networks
 from payme.classes.cards import Cards
@@ -11,14 +10,14 @@ class Payme:
     """
     The payme class provides a simple interface
     """
+
     def __init__(
         self,
         payme_id: str,
-        fallback_id: Union[str, None] = None,
-        payme_key: Union[str, None] = None,
-        is_test_mode: bool = False
-    ):
-
+        fallback_id: t.Optional[str] = None,
+        payme_key: t.Optional[str] = None,
+        is_test_mode: bool = False,
+    ) -> None:
         # initialize payme network
         url = Networks.PROD_NET.value
 
@@ -26,5 +25,8 @@ class Payme:
             url = Networks.TEST_NET.value
 
         self.cards = Cards(url=url, payme_id=payme_id)
-        self.initializer = Initializer(payme_id=payme_id, fallback_id=fallback_id, is_test_mode=is_test_mode)
-        self.receipts = Receipts(url=url, payme_id=payme_id, payme_key=payme_key)  # noqa
+        self.initializer = Initializer(
+            payme_id=payme_id, fallback_id=fallback_id, is_test_mode=is_test_mode
+        )
+        if payme_key:
+            self.receipts = Receipts(url=url, payme_id=payme_id, payme_key=payme_key)

--- a/payme/classes/initializer.py
+++ b/payme/classes/initializer.py
@@ -13,17 +13,14 @@ class Initializer:
         The Payme ID associated with your account
     """
 
-    def __init__(self, payme_id: str = None, fallback_id: str = None, is_test_mode: bool = False):
+    def __init__(
+        self, payme_id: str = None, fallback_id: str = None, is_test_mode: bool = False
+    ) -> None:
         self.payme_id = payme_id
         self.fallback_id = fallback_id
         self.is_test_mode = is_test_mode
 
-    def generate_pay_link(
-        self,
-        id: int,
-        amount: int,
-        return_url: str
-    ) -> str:
+    def generate_pay_link(self, id: int, amount: int, return_url: str) -> str:
         """
         Generate a payment link for a specific order.
 
@@ -52,9 +49,7 @@ class Initializer:
         https://developer.help.paycom.uz/initsializatsiya-platezhey/
         """
         amount = amount * 100  # Convert amount to the smallest currency unit
-        params = (
-            f'm={self.payme_id};ac.{settings.PAYME_ACCOUNT_FIELD}={id};a={amount};c={return_url}'
-        )
+        params = f"m={self.payme_id};ac.{settings.PAYME_ACCOUNT_FIELD}={id};a={amount};c={return_url}"
         params = base64.b64encode(params.encode("utf-8")).decode("utf-8")
 
         if self.is_test_mode is True:

--- a/payme/classes/receipts.py
+++ b/payme/classes/receipts.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+import typing as t
 
 from payme.classes.cards import Cards
 from payme.classes.http import HttpClient
@@ -20,7 +20,8 @@ class Receipts:
     """
     The Receipts class provides methods to interact with the Payme Receipts.
     """
-    def __init__(self, payme_id: str, payme_key: str, url: str) -> "Receipts":
+
+    def __init__(self, payme_id: str, payme_key: str, url: str) -> None:
         """
         Initialize the Receipts client.
 
@@ -32,25 +33,25 @@ class Receipts:
 
         headers = {
             "X-Auth": f"{payme_id}:{payme_key}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         self.http = HttpClient(url, headers)
 
     def create(
         self,
         account: dict,
-        amount: Union[float, int],
-        description: Optional[str] = None,
-        detail: Optional[dict] = None,
-        timeout: int = 10
+        amount: t.Union[float, int],
+        description: t.Optional[str] = None,
+        detail: t.Optional[dict] = None,
+        timeout: int = 10,
     ) -> response.CreateResponse:
         """
         Create a new receipt.
 
         :param account: The account details for the receipt.
         :param amount: The amount of the receipt.
-        :param description: Optional description for the receipt.
-        :param detail: Optional additional details for the receipt.
+        :param description: t.Optional description for the receipt.
+        :param detail: t.Optional additional details for the receipt.
         :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.create"
@@ -58,7 +59,7 @@ class Receipts:
             "amount": amount,
             "account": account,
             "description": description,
-            "detail": detail
+            "detail": detail,
         }
         return self._post_request(method, params, timeout)
 
@@ -74,10 +75,7 @@ class Receipts:
             The request timeout duration in seconds (default is 10).
         """
         method = "receipts.pay"
-        params = {
-            "id": receipts_id,
-            "token": token
-        }
+        params = {"id": receipts_id, "token": token}
         return self._post_request(method, params, timeout)
 
     def send(
@@ -91,15 +89,10 @@ class Receipts:
         :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.send"
-        params = {
-            "id": receipts_id,
-            "phone": phone
-        }
+        params = {"id": receipts_id, "phone": phone}
         return self._post_request(method, params, timeout)
 
-    def cancel(
-        self, receipts_id: str, timeout: int = 10
-    ) -> response.CancelResponse:
+    def cancel(self, receipts_id: str, timeout: int = 10) -> response.CancelResponse:
         """
         Cancel the receipt.
 
@@ -107,14 +100,10 @@ class Receipts:
         :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.cancel"
-        params = {
-            "id": receipts_id
-        }
+        params = {"id": receipts_id}
         return self._post_request(method, params, timeout)
 
-    def check(
-        self, receipts_id: str, timeout: int = 10
-    ) -> response.CheckResponse:
+    def check(self, receipts_id: str, timeout: int = 10) -> response.CheckResponse:
         """
         Check the status of a cheque.
 
@@ -122,14 +111,10 @@ class Receipts:
         :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.check"
-        params = {
-            "id": receipts_id
-        }
+        params = {"id": receipts_id}
         return self._post_request(method, params, timeout)
 
-    def get(
-        self, receipts_id: str, timeout: int = 10
-    ) -> response.GetResponse:
+    def get(self, receipts_id: str, timeout: int = 10) -> response.GetResponse:
         """
         Get the details of a specific cheque.
 
@@ -137,30 +122,23 @@ class Receipts:
         :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.get"
-        params = {
-            "id": receipts_id
-        }
+        params = {"id": receipts_id}
         return self._post_request(method, params, timeout)
 
     def get_all(
         self, count: int, from_: int, to: int, offset: int, timeout: int = 10
     ) -> response.GetAllResponse:
         """
-        Get all cheques for a specific account.
+         Get all cheques for a specific account.
 
-        :param count: The number of cheques to retrieve.
-        :param from_: The start index of the cheques to retrieve.
-        :param to: The end index of the cheques to retrieve.
-        :param offset: The offset for pagination.
-       :param timeout: The request timeout duration in seconds (default 10).
+         :param count: The number of cheques to retrieve.
+         :param from_: The start index of the cheques to retrieve.
+         :param to: The end index of the cheques to retrieve.
+         :param offset: The offset for pagination.
+        :param timeout: The request timeout duration in seconds (default 10).
         """
         method = "receipts.get_all"
-        params = {
-            "count": count,
-            "from": from_,
-            "to": to,
-            "offset": offset
-        }
+        params = {"count": count, "from": from_, "to": to, "offset": offset}
         return self._post_request(method, params, timeout)
 
     def _post_request(
@@ -185,6 +163,7 @@ class Receipts:
         covering creation, payment, sending, cancellation, status checks,
         retrieval of a single receipt, and retrieval of multiple receipts.
         """
+
         # Helper to assert conditions with messaging
         def assert_condition(condition, message, test_case):
             self._assert_and_print(condition, message, test_case=test_case)
@@ -195,14 +174,14 @@ class Receipts:
                 account={"id": 12345},
                 amount=1000,
                 description="Test receipt",
-                detail={"key": "value"}
+                detail={"key": "value"},
             )
 
         # Test 1: Initialization check
         assert_condition(
             isinstance(self, Receipts),
             "Initialized Receipts class successfully.",
-            test_case="Initialization Test"
+            test_case="Initialization Test",
         )
 
         # Test 2: Create and Pay Receipt
@@ -210,21 +189,19 @@ class Receipts:
         assert_condition(
             isinstance(create_response, response.CreateResponse),
             "Created a new receipt successfully.",
-            test_case="Receipt Creation Test"
+            test_case="Receipt Creation Test",
         )
 
         # pylint: disable=W0212
         assert_condition(
             isinstance(create_response.result.receipt._id, str),
             "Created a valid receipt ID.",
-            test_case="Receipt ID Test"
+            test_case="Receipt ID Test",
         )
 
         # Prepare card and verification
         cards_create_response = self.__cards.create(
-            number="8600495473316478",
-            expire="0399",
-            save=True
+            number="8600495473316478", expire="0399", save=True
         )
         token = cards_create_response.result.card.token
         self.__cards.get_verify_code(token=token)
@@ -236,7 +213,7 @@ class Receipts:
         assert_condition(
             pay_response.result.receipt.state == 4,
             "Paid the receipt successfully.",
-            test_case="Payment Test"
+            test_case="Payment Test",
         )
 
         # Test 3: Create and Send Receipt
@@ -246,7 +223,7 @@ class Receipts:
         assert_condition(
             send_response.result.success is True,
             "Sent the receipt successfully.",
-            test_case="Send Test"
+            test_case="Send Test",
         )
 
         # Test 4: Create and Cancel Receipt
@@ -256,7 +233,7 @@ class Receipts:
         assert_condition(
             cancel_response.result.receipt.state == 50,
             "Cancelled the receipt successfully.",
-            test_case="Cancel Test"
+            test_case="Cancel Test",
         )
 
         # Test 5: Check Receipt Status
@@ -264,7 +241,7 @@ class Receipts:
         assert_condition(
             check_response.result.state == 50,
             "Checked the receipt status successfully.",
-            test_case="Check Test"
+            test_case="Check Test",
         )
 
         # Test 6: Get Receipt Details
@@ -272,27 +249,21 @@ class Receipts:
         assert_condition(
             get_response.result.receipt._id == receipt_id,
             "Retrieved the receipt details successfully.",
-            test_case="Get Test"
+            test_case="Get Test",
         )
 
         # Test 7: Retrieve All Receipts
         get_all_response = self.get_all(
-            count=1,
-            from_=1730322122000,
-            to=1730398982000,
-            offset=0
+            count=1, from_=1730322122000, to=1730398982000, offset=0
         )
         assert_condition(
             isinstance(get_all_response.result, list),
             "Retrieved all receipts successfully.",
-            test_case="Get All Test"
+            test_case="Get All Test",
         )
 
     # pylint: disable=W0212
     def _assert_and_print(
-        self,
-        condition: bool,
-        success_message: str,
-        test_case: Optional[str] = None
+        self, condition: bool, success_message: str, test_case: t.Optional[str] = None
     ):
         self.__cards._assert_and_print(condition, success_message, test_case)

--- a/payme/classes/receipts.py
+++ b/payme/classes/receipts.py
@@ -42,7 +42,7 @@ class Receipts:
         account: dict,
         amount: t.Union[float, int],
         description: t.Optional[str] = None,
-        detail: t.Optional[dict] = None,
+        detail: t.Optional[t.Dict] = None,
         timeout: int = 10,
     ) -> response.CreateResponse:
         """

--- a/payme/exceptions/webhook.py
+++ b/payme/exceptions/webhook.py
@@ -1,28 +1,31 @@
 """
 Init Payme base exception.
 """
+
 import logging
+import typing as t
+
+from rest_framework import status
 from rest_framework.exceptions import APIException
 
 logger = logging.getLogger(__name__)
+
+MessageT = t.Optional[t.Union[str, t.Dict[str, str]]]
 
 
 class BasePaymeException(APIException):
     """
     BasePaymeException inherits from APIException.
     """
-    status_code = 200
-    error_code = None
-    message = None
+
+    status_code: int = status.HTTP_200_OK
+    error_code: t.Optional[int] = None
+    message: MessageT = None
 
     # pylint: disable=super-init-not-called
     def __init__(self, message: str = None):
         detail: dict = {
-            "error": {
-                "code": self.error_code,
-                "message": self.message,
-                "data": message
-            }
+            "error": {"code": self.error_code, "message": self.message, "data": message}
         }
         logger.error(f"Payme error detail: {detail}")
         self.detail = detail
@@ -34,7 +37,8 @@ class PermissionDenied(BasePaymeException):
 
     Raised when the client is not allowed to access the server.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -32504
     message = "Permission denied."
 
@@ -45,12 +49,13 @@ class InternalServiceError(BasePaymeException):
 
     Raised when a transaction fails to perform.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -32400
     message = {
         "uz": "Tizimda xatolik yuzaga keldi.",
         "ru": "Внутренняя ошибка сервиса.",
-        "en": "Internal service error."
+        "en": "Internal service error.",
     }
 
 
@@ -60,7 +65,8 @@ class MethodNotFound(BasePaymeException):
 
     Raised when the requested method does not exist.
     """
-    status_code = 405
+
+    status_code = status.HTTP_405_METHOD_NOT_ALLOWED
     error_code = -32601
     message = "Method not found."
 
@@ -71,12 +77,13 @@ class AccountDoesNotExist(BasePaymeException):
 
     Raised when an account does not exist or has been deleted.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -31050
     message = {
         "uz": "Hisob topilmadi.",
         "ru": "Счет не найден.",
-        "en": "Account does not exist."
+        "en": "Account does not exist.",
     }
 
 
@@ -86,12 +93,13 @@ class IncorrectAmount(BasePaymeException):
 
     Raised when the provided amount is incorrect.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -31001
     message = {
-        'ru': 'Неверная сумма.',
-        'uz': "Noto'g'ri summa.",
-        'en': 'Incorrect amount.'
+        "ru": "Неверная сумма.",
+        "uz": "Noto'g'ri summa.",
+        "en": "Incorrect amount.",
     }
 
 
@@ -107,12 +115,13 @@ class TransactionAlreadyExists(BasePaymeException):
         error_code (int): The specific error code for this exception.
         message (dict): A dictionary containing localized error messages.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -31099
     message = {
         "uz": "Tranzaksiya allaqachon mavjud.",
         "ru": "Транзакция уже существует.",
-        "en": "Transaction already exists."
+        "en": "Transaction already exists.",
     }
 
 
@@ -122,12 +131,13 @@ class InvalidFiscalParams(BasePaymeException):
 
     Raised when the provided fiscal parameters are invalid.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -32602
     message = {
         "uz": "Fiskal parameterlarida kamchiliklar bor",
         "ru": "Неверные фискальные параметры.",
-        "en": "Invalid fiscal parameters."
+        "en": "Invalid fiscal parameters.",
     }
 
 
@@ -137,12 +147,13 @@ class InvalidAccount(BasePaymeException):
 
     Raised when the provided account is invalid.
     """
-    status_code = 200
+
+    status_code = status.HTTP_200_OK
     error_code = -32400
     message = {
         "uz": "Hisob nomida kamchilik bor",
         "ru": "Неверный номер счета.",
-        "en": "Invalid account."
+        "en": "Invalid account.",
     }
 
 
@@ -153,5 +164,5 @@ exception_whitelist = (
     AccountDoesNotExist,
     TransactionAlreadyExists,
     InvalidFiscalParams,
-    InvalidAccount
+    InvalidAccount,
 )

--- a/payme/types/response/cards.py
+++ b/payme/types/response/cards.py
@@ -1,14 +1,15 @@
-from typing import Dict, Optional
+import typing as t
 from dataclasses import dataclass
 
 
+@dataclass
 class Common:
     """
     The common response structure.
     """
 
     @classmethod
-    def from_dict(cls, data: Dict):
+    def from_dict(cls, data: t.Dict):
         """
         Prepare fields for nested dataclasses
         """
@@ -30,13 +31,14 @@ class Card(Common):
     """
     The card object represents a credit card.
     """
+
     number: str
     expire: str
     token: str
     recurrent: bool
     verify: bool
     type: str
-    number_hash: Optional[str] = None
+    number_hash: t.Optional[str] = None
 
 
 @dataclass
@@ -44,6 +46,7 @@ class Result(Common):
     """
     The result object contains the created card.
     """
+
     card: Card
 
 
@@ -52,6 +55,7 @@ class CardsCreateResponse(Common):
     """
     The cards.create response.
     """
+
     jsonrpc: str
     result: Result
 
@@ -61,6 +65,7 @@ class VerifyResult(Common):
     """
     The result object for the verification response.
     """
+
     sent: bool
     phone: str
     wait: int
@@ -71,6 +76,7 @@ class GetVerifyResponse(Common):
     """
     The verification response structure.
     """
+
     jsonrpc: str
     result: VerifyResult
 
@@ -80,6 +86,7 @@ class VerifyResponse(Common):
     """
     The verification response structure.
     """
+
     jsonrpc: str
     result: Result
 
@@ -89,6 +96,7 @@ class RemoveCardResult(Common):
     """
     The result object for the removal response.
     """
+
     success: bool
 
 
@@ -97,6 +105,7 @@ class RemoveResponse(Common):
     """
     The remove response structure.
     """
+
     jsonrpc: str
     result: RemoveCardResult
 
@@ -106,5 +115,6 @@ class CheckResponse(Common):
     """
     The check response structure.
     """
+
     jsonrpc: str
     result: Result

--- a/payme/types/response/receipts.py
+++ b/payme/types/response/receipts.py
@@ -142,7 +142,7 @@ class Receipt(Common):
     creator: t.Optional[str] = None
     payer: t.Optional[Payer] = None
     amount: t.Optional[t.Union[float, int]] = None
-    account: t.Optional[list[Account]] = None
+    account: t.Optional[t.List[Account]] = None
     merchant: t.Optional[Merchant] = None
     processing_id: t.Optional[str] = None
     meta: t.Optional[Meta] = None
@@ -229,4 +229,4 @@ class GetAllResponse(Common):
     The result object for the get all response.
     """
 
-    result: t.Optional[list[Receipt]] = None
+    result: t.Optional[t.List[Receipt]] = None

--- a/payme/types/response/receipts.py
+++ b/payme/types/response/receipts.py
@@ -1,16 +1,18 @@
+import typing as t
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
 
 
+@dataclass
 class Common:
     """
     The common response structure.
     """
+
     jsonrpc: str
     id: int
 
     @classmethod
-    def from_dict(cls, data: Dict):
+    def from_dict(cls, data: t.Dict):
         """
         Prepare fields for nested dataclasses
         """
@@ -32,6 +34,7 @@ class Account(Common):
     """
     The account object represents a user's banking account.
     """
+
     _id: str
     account_number: str
     account_name: str
@@ -46,10 +49,11 @@ class PaymentMethod(Common):
     """
     The payment method object represents a user's payment method.
     """
+
     name: str
     title: str
     value: str
-    main: Optional[bool] = None
+    main: t.Optional[bool] = None
 
 
 @dataclass
@@ -57,9 +61,10 @@ class Detail(Common):
     """
     The detail object represents additional details for a receipt.
     """
-    discount: Optional[str] = None
-    shipping: Optional[str] = None
-    items: Optional[str] = None
+
+    discount: t.Optional[str] = None
+    shipping: t.Optional[str] = None
+    items: t.Optional[str] = None
 
 
 # pylint: disable=C0103
@@ -68,6 +73,7 @@ class MerchantEpos(Common):
     """
     The merchantEpos object represents a user's ePOS.
     """
+
     eposId: str
     eposName: str
     eposType: str
@@ -79,9 +85,10 @@ class Meta(Common):
     """
     The meta object represents additional metadata for a receipt.
     """
-    source: any = None
-    owner: any = None
-    host: any = None
+
+    source: t.Any = None
+    owner: t.Any = None
+    host: t.Any = None
 
 
 @dataclass
@@ -89,17 +96,18 @@ class Merchant:
     """
     The merchant object represents a user's merchant.
     """
+
     _id: str
     name: str
     organization: str
-    address: Optional[str] = None
-    business_id: Optional[str] = None
-    epos: Optional[MerchantEpos] = None
-    restrictions: Optional[str] = None
-    date: Optional[int] = None
-    logo: Optional[str] = None
-    type: Optional[str] = None
-    terms: Optional[str] = None
+    address: t.Optional[str] = None
+    business_id: t.Optional[str] = None
+    epos: t.Optional[MerchantEpos] = None
+    restrictions: t.Optional[str] = None
+    date: t.Optional[int] = None
+    logo: t.Optional[str] = None
+    type: t.Optional[str] = None
+    terms: t.Optional[str] = None
 
 
 @dataclass
@@ -107,6 +115,7 @@ class Payer(Common):
     """
     The payer object represents a user's payer.
     """
+
     phone: str
 
 
@@ -115,6 +124,7 @@ class Receipt(Common):
     """
     The receipt object represents a payment receipt.
     """
+
     _id: str
     create_time: int
     pay_time: int
@@ -123,19 +133,19 @@ class Receipt(Common):
     type: int
     external: bool
     operation: int
-    error: any = None
-    description: str = None
-    detail: Detail = None
-    currency: int = None
-    commission: int = None
-    card: str = None
-    creator: str = None
-    payer: Payer = None
-    amount: Union[float, int] = None
-    account: list[Account] = None
-    merchant: Merchant = None
-    processing_id: str = None
-    meta: Meta = None
+    error: t.Any = None
+    description: t.Optional[str] = None
+    detail: t.Optional[Detail] = None
+    currency: t.Optional[int] = None
+    commission: t.Optional[int] = None
+    card: t.Optional[str] = None
+    creator: t.Optional[str] = None
+    payer: t.Optional[Payer] = None
+    amount: t.Optional[t.Union[float, int]] = None
+    account: t.Optional[list[Account]] = None
+    merchant: t.Optional[Merchant] = None
+    processing_id: t.Optional[str] = None
+    meta: t.Optional[Meta] = None
 
 
 @dataclass
@@ -143,6 +153,7 @@ class CreateResult(Common):
     """
     The result object for the create response.
     """
+
     receipt: Receipt
 
 
@@ -151,6 +162,7 @@ class CreateResponse(Common):
     """
     The create response structure.
     """
+
     result: CreateResult
 
 
@@ -166,6 +178,7 @@ class SendResult(Common):
     """
     The result object for the send response.
     """
+
     success: bool
 
 
@@ -174,6 +187,7 @@ class SendResponse(Common):
     """
     The send response structure.
     """
+
     result: SendResult
 
 
@@ -189,6 +203,7 @@ class CheckResult(Common):
     """
     The result object for the check response.
     """
+
     state: int
 
 
@@ -197,6 +212,7 @@ class CheckResponse(Common):
     """
     The check response structure.
     """
+
     result: CheckResult
 
 
@@ -212,4 +228,5 @@ class GetAllResponse(Common):
     """
     The result object for the get all response.
     """
-    result: list[Receipt] = None
+
+    result: t.Optional[list[Receipt]] = None

--- a/payme/types/response/webhook.py
+++ b/payme/types/response/webhook.py
@@ -1,15 +1,16 @@
+import typing as t
 from dataclasses import dataclass, field
-from typing import List, Optional, Dict
 
 
 class CommonResponse:
     """
     The common response structure
     """
+
     def as_resp(self):
-        response = {'result': {}}
+        response = {"result": {}}
         for key, value in self.__dict__.items():
-            response['result'][key] = value
+            response["result"][key] = value
         return response
 
 
@@ -18,6 +19,7 @@ class Shipping(CommonResponse):
     """
     Shipping information response structure
     """
+
     title: str
     price: int
 
@@ -27,6 +29,7 @@ class Item(CommonResponse):
     """
     Item information response structure
     """
+
     discount: int
     title: str
     price: int
@@ -45,7 +48,7 @@ class Item(CommonResponse):
             "code": self.code,
             "units": self.units,
             "vat_percent": self.vat_percent,
-            "package_code": self.package_code
+            "package_code": self.package_code,
         }
 
 
@@ -54,11 +57,12 @@ class CheckPerformTransaction(CommonResponse):
     """
     Receipt information response structure for transaction checks.
     """
+
     allow: bool
-    additional: Optional[Dict[str, str]] = None
-    receipt_type: Optional[int] = None
-    shipping: Optional[Shipping] = None
-    items: List[Item] = field(default_factory=list)
+    additional: t.Optional[t.Dict[str, str]] = None
+    receipt_type: t.Optional[int] = None
+    shipping: t.Optional[Shipping] = None
+    items: t.List[Item] = field(default_factory=list)
 
     def add_item(self, item: Item):
         self.items.append(item)
@@ -90,9 +94,10 @@ class CreateTransaction(CommonResponse):
     """
     The create transaction request
     """
+
     transaction: str
     state: str
-    create_time: str
+    create_time: int
 
 
 @dataclass
@@ -100,9 +105,10 @@ class PerformTransaction(CommonResponse):
     """
     The perform transaction response
     """
+
     transaction: str
     state: str
-    perform_time: str
+    perform_time: int
 
 
 @dataclass
@@ -110,6 +116,7 @@ class CancelTransaction(CommonResponse):
     """
     The cancel transaction request
     """
+
     transaction: str
     state: str
     cancel_time: str
@@ -120,12 +127,13 @@ class CheckTransaction(CommonResponse):
     """
     The check transaction request
     """
+
     transaction: str
     state: str
     reason: str
-    create_time: str
-    perform_time: Optional[str] = None
-    cancel_time: Optional[str] = None
+    create_time: int
+    perform_time: t.Optional[int] = None
+    cancel_time: t.Optional[int] = None
 
 
 @dataclass
@@ -133,7 +141,8 @@ class GetStatement(CommonResponse):
     """
     The check perform transactions response
     """
-    transactions: List[str]
+
+    transactions: t.List[t.Dict[str, str | int | t.Dict[str, str | int]]]
 
 
 @dataclass
@@ -141,4 +150,5 @@ class SetFiscalData(CommonResponse):
     """
     The set fiscal data request
     """
+
     success: bool


### PR DESCRIPTION
*  Type annotation for "any" is misused,  replaced any`(built-in function) type annotation `Any` (from typing module)
* Constructors should not return *anything*
* Fixed other incompatible type hints (like `field: str = None`, which should be not just `str`, but optional string)
* Using `Optional[T]` instead of `Union[T, None]` (shorthand) 
* Using type classes from `typing` module to support older python versions (e.g. using `t.List[str]` instead of `list[str]`)

Looking for reviews.